### PR TITLE
Fix bug django-roxy when using with Django 1.7

### DIFF
--- a/roxy/__init__.py
+++ b/roxy/__init__.py
@@ -13,7 +13,10 @@ def _load_post_and_files(self):
     """
     # This statement have a side-effect that loads raw post data to _raw_post_data
     # pylint: disable=W0104
-    self.raw_post_data
+    if hasattr(self, 'body'):
+        self.body
+    else:
+        self.raw_post_data
     return self._orig_load_post_and_files()    # pylint: disable=W0212
 HttpRequest._load_post_and_files = _load_post_and_files
 

--- a/roxy/views.py
+++ b/roxy/views.py
@@ -58,9 +58,13 @@ def proxy(origin_server):
         # Send request
         http = Http(**_httplib2_constructor_kwargs)
         http.follow_redirects = False
+        if hasattr(request, 'body'):
+            request_body = request.body
+        else:
+            request_body = request.raw_post_data
         httplib2_response, content = http.request(
             target_url, request.method,
-            body=bytearray(request.raw_post_data),
+            body=bytearray(request_body),
             headers=headers)
 
         # Construct Django HttpResponse

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def read(fname):
 
 setup(
     name = "django-roxy",
-    version = "0.2.6",
+    version = "0.2.6.1",
     author = "Proteus Technologies Development team",
     author_email = "infrastructure@proteus-tech.com",
     description = ("Simple reverse proxy for Django"),


### PR DESCRIPTION
the `request.raw_post_data` is depricate on Django 1.6. I saw some code still using this so I change logic to check for attribute `body` which is the replacement for `raw_post_data`. which mean that django-roxy are still able to operate on Django 1.7 and 1.6 or Older.
